### PR TITLE
Add sequential AES-128 wrapper with byte-wide interface

### DIFF
--- a/encrypt/key128/aes_encrypt_128_serial.sv
+++ b/encrypt/key128/aes_encrypt_128_serial.sv
@@ -1,0 +1,170 @@
+// Sequential wrapper around the combinational AES-128 encryptor that
+// reduces the plaintext, key and cipher interfaces to 8-bit transfers.
+module aes_encrypt_128_serial (
+        input  logic        clk,
+        input  logic        rst_n,
+        input  logic        start,
+        input  logic [7:0]  plain_byte,
+        input  logic        plain_valid,
+        output logic        plain_ready,
+        input  logic [7:0]  key_byte,
+        input  logic        key_valid,
+        output logic        key_ready,
+        output logic [7:0]  cipher_byte,
+        output logic        cipher_valid,
+        input  logic        cipher_ready,
+        output logic        busy,
+        output logic        done
+);
+
+        typedef enum logic [2:0] {
+                S_IDLE,
+                S_LOAD_PLAIN,
+                S_LOAD_KEY,
+                S_COMPUTE,
+                S_OUTPUT
+        } state_t;
+
+        state_t state, next_state;
+        logic [3:0] plain_count;
+        logic [3:0] key_count;
+        logic [3:0] out_count;
+
+        logic [127:0] plain_block;
+        logic [127:0] key_block;
+        logic [127:0] cipher_shift;
+
+        wire [127:0] key1_unused, key2_unused, key3_unused, key4_unused,
+                     key5_unused, key6_unused, key7_unused, key8_unused,
+                     key9_unused, key10_unused;
+        wire [127:0] round0_unused, round1_unused, round2_unused, round3_unused,
+                     round4_unused, round5_unused, round6_unused, round7_unused,
+                     round8_unused, round9_unused;
+        wire [127:0] cipher_wire;
+
+        aes_encrypt_128 comb (
+                .plain(plain_block),
+                .key(key_block),
+                .key1(key1_unused),
+                .key2(key2_unused),
+                .key3(key3_unused),
+                .key4(key4_unused),
+                .key5(key5_unused),
+                .key6(key6_unused),
+                .key7(key7_unused),
+                .key8(key8_unused),
+                .key9(key9_unused),
+                .key10(key10_unused),
+                .round0(round0_unused),
+                .round1(round1_unused),
+                .round2(round2_unused),
+                .round3(round3_unused),
+                .round4(round4_unused),
+                .round5(round5_unused),
+                .round6(round6_unused),
+                .round7(round7_unused),
+                .round8(round8_unused),
+                .round9(round9_unused),
+                .cipher(cipher_wire)
+        );
+
+        assign plain_ready  = (state == S_LOAD_PLAIN);
+        assign key_ready    = (state == S_LOAD_KEY);
+        assign cipher_valid = (state == S_OUTPUT);
+        assign cipher_byte  = cipher_shift[127:120];
+        assign busy         = (state != S_IDLE);
+
+        always_ff @(posedge clk or negedge rst_n) begin
+                if (!rst_n) begin
+                        state        <= S_IDLE;
+                        plain_count  <= '0;
+                        key_count    <= '0;
+                        out_count    <= '0;
+                        plain_block  <= '0;
+                        key_block    <= '0;
+                        cipher_shift <= '0;
+                        done         <= 1'b0;
+                end else begin
+                        state <= next_state;
+                        done  <= 1'b0;
+
+                        unique case (state)
+                                S_IDLE: begin
+                                        if (start) begin
+                                                plain_block  <= '0;
+                                                key_block    <= '0;
+                                                cipher_shift <= '0;
+                                                plain_count  <= '0;
+                                                key_count    <= '0;
+                                                out_count    <= '0;
+                                        end
+                                end
+
+                                S_LOAD_PLAIN: begin
+                                        if (plain_valid && plain_ready) begin
+                                                plain_block <= {plain_block[119:0], plain_byte};
+                                                plain_count <= plain_count + 1'b1;
+                                        end
+                                end
+
+                                S_LOAD_KEY: begin
+                                        if (key_valid && key_ready) begin
+                                                key_block <= {key_block[119:0], key_byte};
+                                                key_count <= key_count + 1'b1;
+                                        end
+                                end
+
+                                S_COMPUTE: begin
+                                        cipher_shift <= cipher_wire;
+                                        out_count    <= '0;
+                                end
+
+                                S_OUTPUT: begin
+                                        if (cipher_valid && cipher_ready) begin
+                                                cipher_shift <= {cipher_shift[119:0], 8'h00};
+                                                out_count    <= out_count + 1'b1;
+                                                if (out_count == 4'd15) begin
+                                                        done <= 1'b1;
+                                                end
+                                        end
+                                end
+                        endcase
+                end
+        end
+
+        always_comb begin
+                next_state = state;
+                unique case (state)
+                        S_IDLE: begin
+                                if (start) begin
+                                        next_state = S_LOAD_PLAIN;
+                                end
+                        end
+
+                        S_LOAD_PLAIN: begin
+                                if (plain_valid && plain_ready && (plain_count == 4'd15)) begin
+                                        next_state = S_LOAD_KEY;
+                                end
+                        end
+
+                        S_LOAD_KEY: begin
+                                if (key_valid && key_ready && (key_count == 4'd15)) begin
+                                        next_state = S_COMPUTE;
+                                end
+                        end
+
+                        S_COMPUTE: begin
+                                next_state = S_OUTPUT;
+                        end
+
+                        S_OUTPUT: begin
+                                if (cipher_valid && cipher_ready && (out_count == 4'd15)) begin
+                                        next_state = S_IDLE;
+                                end
+                        end
+
+                        default: next_state = S_IDLE;
+                endcase
+        end
+
+endmodule

--- a/encrypt/key128/aes_encrypt_serial_tb.sv
+++ b/encrypt/key128/aes_encrypt_serial_tb.sv
@@ -1,0 +1,119 @@
+module aes_encrypt_serial_tb;
+        logic clk;
+        logic rst_n;
+
+        logic start;
+        logic [7:0] plain_byte;
+        logic plain_valid;
+        wire plain_ready;
+        logic [7:0] key_byte;
+        logic key_valid;
+        wire key_ready;
+        wire [7:0] cipher_byte;
+        wire cipher_valid;
+        logic cipher_ready;
+        wire busy;
+        wire done;
+
+        aes_encrypt_128_serial dut (
+                .clk(clk),
+                .rst_n(rst_n),
+                .start(start),
+                .plain_byte(plain_byte),
+                .plain_valid(plain_valid),
+                .plain_ready(plain_ready),
+                .key_byte(key_byte),
+                .key_valid(key_valid),
+                .key_ready(key_ready),
+                .cipher_byte(cipher_byte),
+                .cipher_valid(cipher_valid),
+                .cipher_ready(cipher_ready),
+                .busy(busy),
+                .done(done)
+        );
+
+        initial begin
+                clk = 1'b0;
+                forever #5 clk = ~clk;
+        end
+
+        byte plain_data [0:15] = '{
+                8'h00, 8'h11, 8'h22, 8'h33,
+                8'h44, 8'h55, 8'h66, 8'h77,
+                8'h88, 8'h99, 8'haa, 8'hbb,
+                8'hcc, 8'hdd, 8'hee, 8'hff
+        };
+
+        byte key_data [0:15] = '{
+                8'h00, 8'h01, 8'h02, 8'h03,
+                8'h04, 8'h05, 8'h06, 8'h07,
+                8'h08, 8'h09, 8'h0a, 8'h0b,
+                8'h0c, 8'h0d, 8'h0e, 8'h0f
+        };
+
+        byte cipher_capture [0:15];
+        integer capture_index;
+
+        logic [127:0] expected_cipher = 128'h69c4e0d86a7b0430d8cdb78070b4c55a;
+        logic [127:0] observed_cipher;
+
+        initial begin
+                rst_n = 1'b0;
+                start = 1'b0;
+                plain_byte = 8'h00;
+                plain_valid = 1'b0;
+                key_byte = 8'h00;
+                key_valid = 1'b0;
+                cipher_ready = 1'b1;
+                capture_index = 0;
+
+                repeat (2) @(posedge clk);
+                rst_n = 1'b1;
+
+                @(posedge clk);
+                start = 1'b1;
+                @(posedge clk);
+                start = 1'b0;
+
+                for (int i = 0; i < 16; i++) begin
+                        @(posedge clk);
+                        wait (plain_ready);
+                        plain_byte = plain_data[i];
+                        plain_valid = 1'b1;
+                        @(posedge clk);
+                        plain_valid = 1'b0;
+                end
+
+                for (int j = 0; j < 16; j++) begin
+                        @(posedge clk);
+                        wait (key_ready);
+                        key_byte = key_data[j];
+                        key_valid = 1'b1;
+                        @(posedge clk);
+                        key_valid = 1'b0;
+                end
+
+                wait (done);
+
+                observed_cipher = '0;
+                for (int k = 0; k < 16; k++) begin
+                        observed_cipher = {observed_cipher[119:0], cipher_capture[k]};
+                end
+
+                if (observed_cipher !== expected_cipher) begin
+                        $error("Cipher mismatch. Expected %032h, got %032h", expected_cipher, observed_cipher);
+                end else begin
+                        $display("Cipher matches expected value: %032h", observed_cipher);
+                end
+
+                $finish;
+        end
+
+        always @(posedge clk) begin
+                if (cipher_valid && cipher_ready) begin
+                        cipher_capture[capture_index] <= cipher_byte;
+                        capture_index <= capture_index + 1;
+                end
+        end
+
+endmodule


### PR DESCRIPTION
## Summary
- add a sequential controller around the combinational AES-128 encryptor to accept and produce 8-bit transfers
- expose handshake signals for byte-wide plaintext, key, and ciphertext streams while keeping the existing core untouched
- include a SystemVerilog testbench that exercises the new interface against the NIST known-answer vector

## Testing
- `iverilog -g2012 -o encrypt/key128/serial_tb encrypt/key128/aes_encrypt_serial_tb.sv encrypt/key128/aes_encrypt_128_serial.sv encrypt/key128/aes_encrypt_128.sv encrypt/key128/*.sv` *(fails: iverilog not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68df3f630c048327b7ae7b1499b32960